### PR TITLE
Removing duplicate Good Will Hunting movie quote.

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -910,12 +910,6 @@
         "year": 1997
     },
     {
-        "quote": "Some people can’t believe in themselves until someone else believes in them first ",
-        "movie": "Good will hunting",
-        "type": "movie",
-        "year": 1997
-    },
-    {
         "quote": "Does anything more dangerous than that lurk just beneath the surface?",
         "movie": "Titanic",
         "type": "movie",


### PR DESCRIPTION
Removing duplicate Good Will Hunting movie quote. Test messed due to capitalization of movie title.