### PR TITLE
Removed duplicate and fixed year of Rick and Morty quote

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -3108,12 +3108,6 @@
     "year": 2014
   },
   {
-    "quote": "Having a family doesn’t mean that you stop being an individual. You know the best thing you can do for the people that depend on you? Be honest with them, even if it means setting them free.",
-    "movie": "Rick and Morty Season 1",
-    "type": "TV",
-    "year": 2014
-  },
-  {
     "quote": "We are all different. However bad life may seem, there is always something you can do, and succeed at. While there's life, there is hope.",
     "movie": "The Theory of Everything",
     "type": "movie",
@@ -3531,12 +3525,6 @@
     "quote": "People walk around, act like they know what hate means. Nah, no one does, until you hate yourself. I mean truly hate yourself. That’s power.",
     "movie": "Mr. Robot",
     "type": "tv",
-    "year": 2017
-  },
-  {
-    "quote": "Having a family doesn’t mean that you stop being an individual. You know the best thing you can do for the people that depend on you? Be honest with them, even if it means setting them free.",
-    "movie": "Rick and Morty",
-    "type": "TV Series",
     "year": 2017
   },
   {

--- a/data/data.json
+++ b/data/data.json
@@ -3567,7 +3567,7 @@
     "quote": "Having a family doesn’t mean that you stop being an individual. You know the best thing you can do for the people that depend on you? Be honest with them, even if it means setting them free.",
     "movie": "Rick and Morty",
     "type": "tv",
-    "year": 2017
+    "year": 2014
   },
   {
     "quote": "Wubba lubba dub dub!",


### PR DESCRIPTION
- Removed duplicate Rick and Morty quote.
- Fixed year the Rick and Morty quote was said, according to this [citing of the quote](https://quotecatalog.com/quote/justin-roiland-having-a-family-1jnXzM1/), referencing the source episode, and the [Wikipedia page](https://en.wikipedia.org/wiki/Meeseeks_and_Destroy) that cites the air date of the episode.